### PR TITLE
Allow tenants to be created without a backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 rapidsms-multitenancy
 =====================
 
+.. image:: https://travis-ci.org/theirc/rapidsms-multitenancy.svg?branch=master
+    :target: https://travis-ci.org/theirc/rapidsms-multitenancy
+
+.. image:: https://coveralls.io/repos/theirc/rapidsms-multitenancy/badge.svg?branch=master
+    :target: https://coveralls.io/r/theirc/rapidsms-multitenancy?branch=master
+
 rapidsms-multitenancy allows you to host multiple RapidSMS instances in one cohesive project.
 
 .. WARNING::

--- a/multitenancy/__init__.py
+++ b/multitenancy/__init__.py
@@ -1,3 +1,3 @@
 "Host multiple RapidSMS instances in one project"
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/multitenancy/forms.py
+++ b/multitenancy/forms.py
@@ -29,7 +29,8 @@ class TenantForm(forms.ModelForm):
         # we can't update backendlinks until tenant and tenantgroup
         # have been saved, so add them to the tenant object and save
         # them in the model save method
-        tenant.unsaved_backendlinks = [self.cleaned_data['backend_link'], ]
+        if self.cleaned_data['backend_link']:
+            tenant.unsaved_backendlinks = [self.cleaned_data['backend_link'], ]
         if commit:
             tenant.save()
         return tenant

--- a/multitenancy/tests/test_forms.py
+++ b/multitenancy/tests/test_forms.py
@@ -43,6 +43,18 @@ class TenantFormTest(TestCase):
         })
         self.assertTrue(form.is_valid(), form.errors)
 
+    def test_tenant_with_no_backend_is_allowed(self):
+        group = mommy.make('TenantGroup')
+        form = TenantForm(data={
+            'name': 'randomname',
+            'slug': 'randomname',
+            'group': group.pk,
+            'backend_link': None,
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        tenant = form.save()
+        self.assertFalse(tenant.backendlink_set.exists())
+
     def test_saving_form_updates_backends(self):
         group = mommy.make('TenantGroup')
         old_link, new_link = mommy.make('BackendLink', _quantity=2)


### PR DESCRIPTION
Apply the fix from theirc/RescueSMS#93, with a test.